### PR TITLE
Add chest loot, equipment slots, and attack effects

### DIFF
--- a/data.js
+++ b/data.js
@@ -5,13 +5,13 @@ const MAP_W = 40, MAP_H = 30; // 40x30 -> 960x720 canvas
 
 // Monsters (D&D-ish)
 const MONSTERS = [
-  {name:'Goblin', ch:'g', hp:6, atk:2, xp:4},
-  {name:'Skeleton', ch:'s', hp:8, atk:3, xp:6},
-  {name:'Orc', ch:'o', hp:12, atk:4, xp:10},
-  {name:'Zombie', ch:'z', hp:14, atk:3, xp:10},
-  {name:'Mimic', ch:'m', hp:10, atk:5, xp:12},
-  {name:'Ogre', ch:'O', hp:18, atk:6, xp:18},
-  {name:'Young Dragon', ch:'D', hp:28, atk:8, xp:30}
+  {name:'Goblin', ch:'g', hp:6, atk:2, xp:4, color:'#22c55e'},
+  {name:'Skeleton', ch:'s', hp:8, atk:3, xp:6, color:'#d4d4d8'},
+  {name:'Orc', ch:'o', hp:12, atk:4, xp:10, color:'#f97316'},
+  {name:'Zombie', ch:'z', hp:14, atk:3, xp:10, color:'#4ade80'},
+  {name:'Mimic', ch:'m', hp:10, atk:5, xp:12, color:'#c084fc'},
+  {name:'Ogre', ch:'O', hp:18, atk:6, xp:18, color:'#a16207'},
+  {name:'Young Dragon', ch:'D', hp:28, atk:8, xp:30, color:'#ef4444'}
 ];
 
 const LOOT = {

--- a/input.js
+++ b/input.js
@@ -6,7 +6,13 @@ function onKey(e){
   else if(['arrowleft','a'].includes(k)){ move(-1,0); G.lastDir=[-1,0]; }
   else if(['arrowright','d'].includes(k)){ move(1,0); G.lastDir=[1,0]; }
   else if(k==='f'){ // melee in facing dir
-    const d=G.lastDir||[0,-1]; const m=entityAt(G.player.x+d[0], G.player.y+d[1]); if(m){ const dmg=Math.max(1, G.player.atk-(m.def||0)); m.hp-=dmg; log(`You strike the ${m.name} for ${dmg}.`); if(m.hp<=0){ gainXP(m.xp); maybeDrop(m); G.entities=G.entities.filter(e=>e!==m);} tick(); } else log('No enemy to strike.');
+    const d=G.lastDir||[0,-1];
+    const m=entityAt(G.player.x+d[0], G.player.y+d[1]);
+    if(m){
+      const dmg=Math.max(1, G.player.atk-(m.def||0));
+      m.hp-=dmg; log(`You strike the ${m.name} for ${dmg}.`); addEffect(G.player.x+d[0], G.player.y+d[1]);
+      if(m.hp<=0){ gainXP(m.xp); maybeDrop(m); G.entities=G.entities.filter(e=>e!==m);} tick();
+    } else log('No enemy to strike.');
   }
   else if(k==='.' || k==='5') wait();
   else if(k===' '){ e.preventDefault(); ability(); }
@@ -31,7 +37,7 @@ document.getElementById('btnRestart').addEventListener('click', ()=>{
   window.removeEventListener('keydown', onKey);
 });
 document.getElementById('btnHelp').addEventListener('click', ()=>{
-  alert('Move: WASD/Arrows | Wait: . | Attack: F | Ability: Space | Pick up: G | Down stairs: >\nInventory: click item or press 1..9');
+  alert('Move: WASD/Arrows | Wait: . | Attack: F | Ability: Space | Pick up/Open chest: G | Down stairs: >\nInventory: click item or press 1..9');
 });
 for(const b of document.querySelectorAll('.classbtn')){
   b.addEventListener('click', ()=> startRun(b.dataset.class));

--- a/render.js
+++ b/render.js
@@ -22,10 +22,29 @@ function render(){
   }
   // items
   for(const it of G.items){ if(!G.seen[it.y][it.x]) continue; ctx.fillStyle = '#ffd166'; ctx.fillRect(it.x*TILE_SIZE+10, it.y*TILE_SIZE+10, 4,4); }
-  // entities
-  for(const e of G.entities){ if(!G.seen[e.y][e.x]) continue; ctx.fillStyle='#76e6ff'; ctx.fillRect(e.x*TILE_SIZE+6,e.y*TILE_SIZE+6,12,12); ctx.fillStyle='#fff'; ctx.font='12px monospace'; ctx.fillText(e.ch, e.x*TILE_SIZE+8, e.y*TILE_SIZE+16); }
+  // entities (monsters)
+  for(const e of G.entities){
+    if(!G.seen[e.y][e.x]) continue;
+    const px=e.x*TILE_SIZE+TILE_SIZE/2, py=e.y*TILE_SIZE+TILE_SIZE/2;
+    ctx.fillStyle=e.color||'#76e6ff';
+    ctx.beginPath(); ctx.arc(px,py,TILE_SIZE/2-3,0,Math.PI*2); ctx.fill();
+  }
   // player
-  ctx.fillStyle = '#2dd4bf'; ctx.fillRect(G.player.x*TILE_SIZE+6, G.player.y*TILE_SIZE+6, 12, 12);
+  const px=G.player.x*TILE_SIZE+TILE_SIZE/2, py=G.player.y*TILE_SIZE+TILE_SIZE/2;
+  ctx.fillStyle = '#2dd4bf';
+  ctx.beginPath(); ctx.arc(px,py,TILE_SIZE/2-3,0,Math.PI*2); ctx.fill();
+
+  // attack effects
+  ctx.lineWidth=2;
+  for(const fx of G.effects){
+    const ex=fx.x*TILE_SIZE, ey=fx.y*TILE_SIZE;
+    ctx.strokeStyle=fx.color;
+    ctx.beginPath();
+    ctx.moveTo(ex,ey); ctx.lineTo(ex+TILE_SIZE,ey+TILE_SIZE);
+    ctx.moveTo(ex+TILE_SIZE,ey); ctx.lineTo(ex,ey+TILE_SIZE);
+    ctx.stroke();
+  }
+  ctx.lineWidth=1;
 }
 
 function renderInv(){
@@ -52,6 +71,8 @@ function updateUI(){
   document.getElementById('uiMP').textContent = `${G.player.mp}/${G.player.mpMax}`;
   document.getElementById('uiGold').textContent = G.gold;
   document.getElementById('uiFloor').textContent = G.floor;
+  document.getElementById('uiWeapon').textContent = G.player.weapon? G.player.weapon.name : 'None';
+  document.getElementById('uiArmor').textContent = G.player.armor? G.player.armor.name : 'None';
   document.getElementById('barHP').style.width = `${Math.max(0, (G.player.hp/G.player.hpMax)*100)}%`;
   document.getElementById('barMP').style.width = `${G.player.mpMax? (G.player.mp/G.player.mpMax)*100 : 0}%`;
   renderInv();

--- a/rogue_lite_single_file_html_game.html
+++ b/rogue_lite_single_file_html_game.html
@@ -69,6 +69,8 @@
       </div>
       <div>
         <div class="row"><span class="badge gold">Gold</span><span id="uiGold">0</span><span class="badge">Floor</span><span id="uiFloor">1</span></div>
+        <div class="row"><span class="badge">Weapon</span><span id="uiWeapon">None</span></div>
+        <div class="row"><span class="badge">Armor</span><span id="uiArmor">None</span></div>
       </div>
       <div>
         <div class="row"><span class="badge">Inventory</span></div>
@@ -80,7 +82,7 @@
       </div>
       <div class="controls">
         <b>Controls</b><br/>
-        Move: WASD / Arrow keys · Wait: . (period) · Attack: F (melee) · Ability: Space (class skill) · Pick up: G · Descend stairs: &gt; <br/>
+        Move: WASD / Arrow keys · Wait: . (period) · Attack: F (melee) · Ability: Space (class skill) · Pick up/Open chest: G · Descend stairs: &gt; <br/>
         Warrior ability: Whirlwind (hit all adjacent) · Mage: Fireball (AoE, 2x2) · Hunter: Shoot arrow (range 5)
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- Allow pressing G on chest tiles to collect random loot and gold
- Track and display equipped weapon and armor with stat bonuses
- Render combat with colored entities and cross-slash attack effects

## Testing
- `node --check data.js game.js input.js render.js utils.js`


------
https://chatgpt.com/codex/tasks/task_e_689562882210832ebd4c383c4785cfc1