### PR TITLE
Replace attack visuals with character icons

### DIFF
--- a/data.js
+++ b/data.js
@@ -5,13 +5,13 @@ const MAP_W = 40, MAP_H = 30; // 40x30 -> 960x720 canvas
 
 // Monsters (D&D-ish)
 const MONSTERS = [
-  {name:'Goblin', ch:'g', hp:6, atk:2, xp:4, color:'#22c55e'},
-  {name:'Skeleton', ch:'s', hp:8, atk:3, xp:6, color:'#d4d4d8'},
-  {name:'Orc', ch:'o', hp:12, atk:4, xp:10, color:'#f97316'},
-  {name:'Zombie', ch:'z', hp:14, atk:3, xp:10, color:'#4ade80'},
-  {name:'Mimic', ch:'m', hp:10, atk:5, xp:12, color:'#c084fc'},
-  {name:'Ogre', ch:'O', hp:18, atk:6, xp:18, color:'#a16207'},
-  {name:'Young Dragon', ch:'D', hp:28, atk:8, xp:30, color:'#ef4444'}
+  {name:'Goblin', icon:'👺', hp:6, atk:2, xp:4},
+  {name:'Skeleton', icon:'💀', hp:8, atk:3, xp:6},
+  {name:'Orc', icon:'👹', hp:12, atk:4, xp:10},
+  {name:'Zombie', icon:'🧟', hp:14, atk:3, xp:10},
+  {name:'Mimic', icon:'📦', hp:10, atk:5, xp:12},
+  {name:'Ogre', icon:'🧌', hp:18, atk:6, xp:18},
+  {name:'Young Dragon', icon:'🐉', hp:28, atk:8, xp:30}
 ];
 
 const LOOT = {
@@ -30,7 +30,7 @@ const LOOT = {
 };
 
 const CLASSES = {
-  warrior: { hp: 30, mp: 0, atk: 5, def: 2, abilityCd: 5 },
-  mage:    { hp: 18, mp: 20, atk: 2, def: 1, abilityCd: 5 },
-  hunter:  { hp: 24, mp: 8,  atk: 3, def: 1, abilityCd: 4 }
+  warrior: { hp: 30, mp: 0, atk: 5, def: 2, abilityCd: 5, icon:'⚔️' },
+  mage:    { hp: 18, mp: 20, atk: 2, def: 1, abilityCd: 5, icon:'🧙' },
+  hunter:  { hp: 24, mp: 8,  atk: 3, def: 1, abilityCd: 4, icon:'🏹' }
 };

--- a/input.js
+++ b/input.js
@@ -10,7 +10,7 @@ function onKey(e){
     const m=entityAt(G.player.x+d[0], G.player.y+d[1]);
     if(m){
       const dmg=Math.max(1, G.player.atk-(m.def||0));
-      m.hp-=dmg; log(`You strike the ${m.name} for ${dmg}.`); addEffect(G.player.x+d[0], G.player.y+d[1]);
+      m.hp-=dmg; log(`You strike the ${m.name} for ${dmg}.`);
       if(m.hp<=0){ gainXP(m.xp); maybeDrop(m); G.entities=G.entities.filter(e=>e!==m);} tick();
     } else log('No enemy to strike.');
   }

--- a/render.js
+++ b/render.js
@@ -1,6 +1,9 @@
 // --- Rendering and UI ---
 const canvas = document.getElementById('view');
 const ctx = canvas.getContext('2d');
+ctx.textAlign = 'center';
+ctx.textBaseline = 'middle';
+ctx.font = '20px sans-serif';
 
 function rect(x,y,w,h,col){ ctx.fillStyle=col; ctx.fillRect(x,y,w,h); }
 
@@ -23,28 +26,15 @@ function render(){
   // items
   for(const it of G.items){ if(!G.seen[it.y][it.x]) continue; ctx.fillStyle = '#ffd166'; ctx.fillRect(it.x*TILE_SIZE+10, it.y*TILE_SIZE+10, 4,4); }
   // entities (monsters)
+  ctx.fillStyle = '#fff';
   for(const e of G.entities){
     if(!G.seen[e.y][e.x]) continue;
     const px=e.x*TILE_SIZE+TILE_SIZE/2, py=e.y*TILE_SIZE+TILE_SIZE/2;
-    ctx.fillStyle=e.color||'#76e6ff';
-    ctx.beginPath(); ctx.arc(px,py,TILE_SIZE/2-3,0,Math.PI*2); ctx.fill();
+    ctx.fillText(e.icon || e.ch || '?', px, py);
   }
   // player
   const px=G.player.x*TILE_SIZE+TILE_SIZE/2, py=G.player.y*TILE_SIZE+TILE_SIZE/2;
-  ctx.fillStyle = '#2dd4bf';
-  ctx.beginPath(); ctx.arc(px,py,TILE_SIZE/2-3,0,Math.PI*2); ctx.fill();
-
-  // attack effects
-  ctx.lineWidth=2;
-  for(const fx of G.effects){
-    const ex=fx.x*TILE_SIZE, ey=fx.y*TILE_SIZE;
-    ctx.strokeStyle=fx.color;
-    ctx.beginPath();
-    ctx.moveTo(ex,ey); ctx.lineTo(ex+TILE_SIZE,ey+TILE_SIZE);
-    ctx.moveTo(ex+TILE_SIZE,ey); ctx.lineTo(ex,ey+TILE_SIZE);
-    ctx.stroke();
-  }
-  ctx.lineWidth=1;
+  ctx.fillText(G.player.icon || '@', px, py);
 }
 
 function renderInv(){


### PR DESCRIPTION
## Summary
- Remove transient attack effects from game state and tick loop
- Render player and monsters as icon glyphs instead of colored circles
- Add emoji icons to class and monster data

## Testing
- `node --check data.js`
- `node --check game.js`
- `node --check render.js`
- `node --check input.js`


------
https://chatgpt.com/codex/tasks/task_e_689567e39bbc832e8fd29f248a06d9f8