### PR TITLE
Add endgame fireworks and kill statistics

### DIFF
--- a/game.js
+++ b/game.js
@@ -12,7 +12,9 @@ const G = {
   gold: 0,
   messages: [],
   effects: [],
-  animating: 0
+  animating: 0,
+  killCounts: {},
+  win: false
 };
 
 function log(msg){
@@ -352,6 +354,7 @@ function move(dx,dy){
 function wait(){ log('You wait.'); tick(); }
 
 function maybeDrop(mon){
+  G.killCounts[mon.name] = (G.killCounts[mon.name] || 0) + 1;
   if(mon.type==='boss'){
     log('The boss drops a brilliant crystal. You have won!');
     winGame();
@@ -496,4 +499,48 @@ function gameOver(){
 function winGame(){
   log('*** You secure the crystal and win the game!');
   window.removeEventListener('keydown', onKey);
+  G.win = true;
+  showWinScreen();
+  launchFireworks();
+}
+
+function launchFireworks(){
+  const spawn=()=>{
+    if(!G.win) return;
+    const x=(Math.random()*MAP_W)|0;
+    const y=(Math.random()*MAP_H)|0;
+    const color=`hsl(${(Math.random()*360)|0},100%,70%)`;
+    playEffect({type:'firework',x,y,color,r:TILE_SIZE*2},700);
+    setTimeout(spawn,500+Math.random()*500);
+  };
+  spawn();
+}
+
+function showWinScreen(){
+  const modal=document.createElement('div');
+  modal.id='winModal';
+  modal.className='modal';
+  modal.style.background='rgba(0,0,0,0.5)';
+  const card=document.createElement('div');
+  card.className='card';
+  card.innerHTML='<h2>Victory!</h2><p>You recovered the crystal!</p>';
+  const stats=document.createElement('div');
+  stats.innerHTML='<h3>Monster Kills</h3>';
+  const list=document.createElement('div');
+  const entries=Object.entries(G.killCounts);
+  if(entries.length){
+    for(const [name,count] of entries){
+      const row=document.createElement('div');
+      row.textContent=`${name}: ${count}`;
+      list.appendChild(row);
+    }
+  } else {
+    const row=document.createElement('div');
+    row.textContent='None';
+    list.appendChild(row);
+  }
+  stats.appendChild(list);
+  card.appendChild(stats);
+  modal.appendChild(card);
+  document.body.appendChild(modal);
 }

--- a/input.js
+++ b/input.js
@@ -30,7 +30,9 @@ function startRun(cls){
   const seedStr = document.getElementById('seed').value.trim();
   G.rng = rngFromSeed(seedStr || undefined);
   G.player = newPlayer(cls);
-  G.floor=1; G.turn=0; G.gold=0; G.messages=[]; G.lastDir=[0,-1];
+  G.floor=1; G.turn=0; G.gold=0; G.messages=[]; G.lastDir=[0,-1]; G.killCounts={}; G.win=false;
+  const winModal=document.getElementById('winModal');
+  if(winModal) winModal.remove();
   genMap(); updateUI(); render();
   document.getElementById('classModal').style.display='none';
   window.addEventListener('keydown', onKey);

--- a/render.js
+++ b/render.js
@@ -71,6 +71,21 @@ function render(){
       const x2=fx.x2*TILE_SIZE+TILE_SIZE/2, y2=fx.y2*TILE_SIZE+TILE_SIZE/2;
       ctx.strokeStyle=fx.color; ctx.lineWidth=2;
       ctx.beginPath(); ctx.moveTo(x1,y1); ctx.lineTo(x2,y2); ctx.stroke();
+    } else if(fx.type==='firework'){
+      const ex=fx.x*TILE_SIZE+TILE_SIZE/2, ey=fx.y*TILE_SIZE+TILE_SIZE/2;
+      const p=fx.elapsed/fx.duration;
+      ctx.strokeStyle=fx.color;
+      ctx.globalAlpha = 1-p;
+      for(let i=0;i<12;i++){
+        const ang=(Math.PI*2/12)*i;
+        const x2=ex+Math.cos(ang)*fx.r*p;
+        const y2=ey+Math.sin(ang)*fx.r*p;
+        ctx.beginPath();
+        ctx.moveTo(ex,ey);
+        ctx.lineTo(x2,y2);
+        ctx.stroke();
+      }
+      ctx.globalAlpha = 1;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Track monster kills and win state
- Show victory screen with kill stats and looping fireworks
- Add fireworks effect rendering

## Testing
- `node --check game.js render.js input.js`


------
https://chatgpt.com/codex/tasks/task_e_689620eb4eec832e82c198c951b4e717