### PR TITLE
Handle pre-game rendering without a player

### DIFF
--- a/render.js
+++ b/render.js
@@ -69,6 +69,7 @@ function buildScene3D(){
 }
 
 function render() {
+  if (!G.player) return;
   if (!USE_WEBGL) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     // tiles
@@ -163,6 +164,7 @@ function renderInv(){
 }
 
 function updateUI(){
+  if(!G.player) return;
   document.getElementById('uiClass').textContent = G.player.cls;
   document.getElementById('uiLvl').textContent = G.player.lvl;
   document.getElementById('uiXP').textContent = `${G.player.xp}/${G.player.nextXp}`;


### PR DESCRIPTION
## Summary
- Avoid rendering UI or canvas before a player is created
- Prevents crash that blocked game start after selecting a class

## Testing
- `node --check render.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689764be9688832eb99f6197da74dd51