### PR TITLE
Serve Three.js from CDN for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "rogue-lite-by-vibe-coding",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rogue-lite-by-vibe-coding",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "three": "^0.161.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.161.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.161.0.tgz",
+      "integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "data.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "mkdir -p build && cp rogue_lite_single_file_html_game.html build/index.html && cp *.js build/",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"
   },

--- a/render.js
+++ b/render.js
@@ -1,4 +1,4 @@
-// import * as THREE from './node_modules/three/build/three.module.js';
+import * as THREE from 'three';
 import { T, TILE_SIZE, MAP_W, MAP_H } from './data.js';
 import { G, useItem, discardItem } from './game.js';
 

--- a/rogue_lite_single_file_html_game.html
+++ b/rogue_lite_single_file_html_game.html
@@ -116,7 +116,7 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "/node_modules/three/build/three.module.js"
+        "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
   </script>


### PR DESCRIPTION
## Summary
- Load Three.js from unpkg CDN instead of local node_modules
- Import Three in renderer and add build script for gh-pages deployment
- Ignore build artifacts and include lockfile for reproducible installs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897797058a4832e900e8489eda15b80