### PR TITLE
fix: reset scene rebuild after map generation

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,6 @@
 import { rngFromSeed } from './utils.js';
 import { T, TILE_SIZE, MAP_W, MAP_H, MONSTERS, LOOT, MERCHANT_ITEMS, BOSS, CLASSES } from './data.js';
-import { render, renderInv, updateUI } from './render.js';
+import { render, renderInv, updateUI, resetScene } from './render.js';
 
 // --- Game State and Logic ---
 export const G = {
@@ -137,7 +137,7 @@ function genMap() {
   }
 
   G.map = map; G.seen = seen; G.effects=[];
-  sceneBuilt = false; // force 3D scene rebuild
+  resetScene(); // force 3D scene rebuild
 
   // place monsters with scaling difficulty
   G.entities=[];

--- a/render.js
+++ b/render.js
@@ -8,6 +8,10 @@ const USE_WEBGL = true;
 const canvas = document.getElementById('view');
 let ctx, renderer3d, scene, camera, playerMesh, entityMeshes = [], sceneBuilt = false;
 
+export function resetScene() {
+  sceneBuilt = false;
+}
+
 if (USE_WEBGL) {
   // Set up a basic Three.js scene
   renderer3d = new THREE.WebGLRenderer({ canvas });


### PR DESCRIPTION
## Summary
- export a `resetScene` helper from `render.js`
- use `resetScene` in `game.js` when generating new map to force 3D scene rebuild

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68978148ba74832e8f6eb7fd61aba88a