### PR TITLE
Improve visuals and add animation fading

### DIFF
--- a/rogue_lite_single_file_html_game.html
+++ b/rogue_lite_single_file_html_game.html
@@ -15,7 +15,7 @@
     }
     html, body { height: 100%; margin: 0; background: var(--bg); color: #e6edf3; font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial; }
     .wrap { display: grid; grid-template-columns: 1fr 320px; gap: 12px; max-width: 1200px; margin: 10px auto; padding: 0 10px; }
-    #view { background: #0a0d12; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); width: 100%; aspect-ratio: 4/3; image-rendering: pixelated; }
+    #view { background: #ffffff; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); width: 100%; aspect-ratio: 4/3; image-rendering: pixelated; }
     .side { background: var(--panel); border-radius: 12px; padding: 12px; display: grid; grid-template-rows: auto auto 1fr auto; gap: 10px; }
     h1 { font-size: 18px; margin: 0 0 4px; color: var(--accent); }
     .row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }


### PR DESCRIPTION
## Summary
- replace cube characters in 3D with simple body/head meshes
- lighten dungeon by drawing tiles and canvas on a white background
- fade whirlwind, fireball, and arrow effects for clearer 2D animations

## Testing
- `node --check render.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68978329c4e8832eaf8e7f81587e9400