### PR TITLE
Add centered 3D view with minimap and enhanced models

### DIFF
--- a/game.js
+++ b/game.js
@@ -387,8 +387,10 @@ function maybeDrop(mon){
     return;
   }
   if(Math.random()<0.7){ const g = (Math.random()*8+2)|0; G.gold+=g; log(`You loot ${g} gold.`); }
+  const before = G.items.length;
   if(Math.random()<0.35){ G.items.push({x:mon.x, y:mon.y, item: JSON.parse(JSON.stringify(LOOT.common[(Math.random()*LOOT.common.length)|0]))}); }
   if(Math.random()<0.12){ G.items.push({x:mon.x, y:mon.y, item: JSON.parse(JSON.stringify(LOOT.rare[(Math.random()*LOOT.rare.length)|0]))}); }
+  if(G.items.length>before) resetScene();
   updateUI();
 }
 

--- a/rogue_lite_single_file_html_game.html
+++ b/rogue_lite_single_file_html_game.html
@@ -15,7 +15,9 @@
     }
     html, body { height: 100%; margin: 0; background: var(--bg); color: #e6edf3; font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial; }
     .wrap { display: grid; grid-template-columns: 1fr 320px; gap: 12px; max-width: 1200px; margin: 10px auto; padding: 0 10px; }
+    .gameview { position: relative; }
     #view { background: #ffffff; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); width: 100%; aspect-ratio: 4/3; image-rendering: pixelated; }
+    #minimap { position: absolute; top: 10px; right: 10px; width: 160px; height: 120px; border: 2px solid #000; image-rendering: pixelated; }
     .side { background: var(--panel); border-radius: 12px; padding: 12px; display: grid; grid-template-rows: auto auto 1fr auto; gap: 10px; }
     h1 { font-size: 18px; margin: 0 0 4px; color: var(--accent); }
     .row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
@@ -45,7 +47,10 @@
 </head>
 <body>
   <div class="wrap">
-    <canvas id="view" width="960" height="720"></canvas>
+    <div class="gameview">
+      <canvas id="view" width="1024" height="768"></canvas>
+      <canvas id="minimap" width="160" height="120"></canvas>
+    </div>
     <aside class="side">
       <div class="topbar">
         <h1>RogueLite</h1>


### PR DESCRIPTION
## Summary
- Center WebGL camera on the player and limit visible tiles to the current vision
- Overlay a minimap that shows explored tiles, monsters, and the player
- Add detailed meshes for dragons, crystal guardian, merchant, stairs, and fountains
- Rebuild 3D scene after monster loot drops so items appear immediately

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897af8d07d4832e9de4e0abb12ce579