### PR TITLE
feat: add mobile controls for mobile devices

### DIFF
--- a/input.js
+++ b/input.js
@@ -54,6 +54,19 @@ for(const b of document.querySelectorAll('.classbtn')){
   b.addEventListener('click', ()=> startRun(b.dataset.class));
 }
 
+// mobile controls
+for(const btn of document.querySelectorAll('#dpad button')){
+  btn.addEventListener('pointerdown', e=>{
+    e.preventDefault();
+    if(G.animating) return;
+    const dx=parseInt(btn.dataset.dx), dy=parseInt(btn.dataset.dy);
+    if(dx===0 && dy===0) wait();
+    else { move(dx,dy); G.lastDir=[dx,dy]; }
+  });
+}
+document.getElementById('btnMobilePickup')?.addEventListener('pointerdown', e=>{ e.preventDefault(); pickup(); });
+document.getElementById('btnMobileAbility')?.addEventListener('pointerdown', e=>{ e.preventDefault(); ability(); });
+
 // Start paused at class select
 updateUI();
 render();

--- a/render.js
+++ b/render.js
@@ -12,6 +12,25 @@ let ctx, renderer3d, scene, camera, playerMesh,
   entityMeshes = [], itemMeshes = [], chestMeshes = [], tileMeshes = [], fxGroup,
   sceneBuilt = false;
 
+function resizeCanvas(){
+  const w = canvas.clientWidth;
+  const h = w * 0.75;
+  canvas.width = w;
+  canvas.height = h;
+  minimap.width = w/6;
+  minimap.height = h/6;
+  if(renderer3d){
+    renderer3d.setSize(w,h);
+    camera.aspect = w/h;
+    camera.updateProjectionMatrix();
+  }
+  if(ctx){
+    ctx.canvas.width = w;
+    ctx.canvas.height = h;
+  }
+}
+window.addEventListener('resize', resizeCanvas);
+
 export function resetScene() {
   sceneBuilt = false;
   entityMeshes = [];
@@ -23,7 +42,6 @@ export function resetScene() {
 if (USE_WEBGL) {
   // Set up a basic Three.js scene
   renderer3d = new THREE.WebGLRenderer({ canvas, antialias: true });
-  renderer3d.setSize(canvas.width, canvas.height);
   renderer3d.setClearColor(0xffffff);
   scene = new THREE.Scene();
   scene.background = new THREE.Color(0xffffff);
@@ -42,6 +60,8 @@ if (USE_WEBGL) {
   ctx.textBaseline = 'middle';
   ctx.font = '20px sans-serif';
 }
+
+resizeCanvas();
 
 function rect(x,y,w,h,col){ ctx.fillStyle=col; ctx.fillRect(x,y,w,h); }
 

--- a/rogue_lite_single_file_html_game.html
+++ b/rogue_lite_single_file_html_game.html
@@ -17,7 +17,7 @@
     .wrap { display: grid; grid-template-columns: 1fr 320px; gap: 12px; max-width: 1200px; margin: 10px auto; padding: 0 10px; }
     .gameview { position: relative; }
     #view { background: #ffffff; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); width: 100%; aspect-ratio: 4/3; image-rendering: pixelated; }
-    #minimap { position: absolute; top: 10px; right: 10px; width: 160px; height: 120px; border: 2px solid #000; image-rendering: pixelated; }
+    #minimap { position: absolute; top: 10px; right: 10px; border: 2px solid #000; image-rendering: pixelated; }
     .side { background: var(--panel); border-radius: 12px; padding: 12px; display: grid; grid-template-rows: auto auto 1fr auto; gap: 10px; }
     h1 { font-size: 18px; margin: 0 0 4px; color: var(--accent); }
     .row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
@@ -43,6 +43,19 @@
     .classbtn h3 { margin: 4px 0; font-size: 16px; color: var(--accent); }
     .classbtn p { margin: 0; font-size: 12px; color: var(--muted); }
     .seed { width: 130px; }
+
+    /* mobile layout */
+    #mobileControls{ display:none; }
+    @media (max-width: 768px){
+      .wrap{ grid-template-columns: 1fr; }
+      .side{ order:2; }
+      .controls{ display:none; }
+      #mobileControls{ position:fixed; left:10px; right:10px; bottom:10px; display:flex; justify-content:space-between; align-items:center; pointer-events:auto; }
+      #dpad{ display:grid; grid-template-columns:repeat(3,60px); grid-template-rows:repeat(3,60px); gap:5px; }
+      #dpad button{ width:60px; height:60px; }
+      #actions{ display:flex; flex-direction:column; gap:10px; }
+      #actions button{ width:80px; height:60px; }
+    }
   </style>
 </head>
 <body>
@@ -92,7 +105,25 @@
         Inventory: click item or press 1..9 to use, Shift+1..9 to drop<br/>
         Warrior ability: Whirlwind (hit all adjacent) · Mage: Fireball (AoE, 2x2) · Hunter: Shoot arrow (range 5)
       </div>
-    </aside>
+  </aside>
+  </div>
+
+  <div id="mobileControls">
+    <div id="dpad">
+      <button class="dir" data-dx="-1" data-dy="-1">↖︎</button>
+      <button class="dir" data-dx="0" data-dy="-1">↑</button>
+      <button class="dir" data-dx="1" data-dy="-1">↗︎</button>
+      <button class="dir" data-dx="-1" data-dy="0">←</button>
+      <button class="dir" data-dx="0" data-dy="0">•</button>
+      <button class="dir" data-dx="1" data-dy="0">→</button>
+      <button class="dir" data-dx="-1" data-dy="1">↙︎</button>
+      <button class="dir" data-dx="0" data-dy="1">↓</button>
+      <button class="dir" data-dx="1" data-dy="1">↘︎</button>
+    </div>
+    <div id="actions">
+      <button id="btnMobilePickup">Pickup</button>
+      <button id="btnMobileAbility">Ability</button>
+    </div>
   </div>
 
   <!-- Class select modal -->


### PR DESCRIPTION
## Summary
- add responsive layout and canvas resizing for mobile play
- introduce on-screen D-pad and buttons for pickup and ability
- handle pointer events for touch-based controls

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897c9caf0b4832e81a457f3931e3352