### PR TITLE
Add randomized brick wall textures and enlarge play area

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,6 @@
 import { rngFromSeed } from './utils.js';
 import { T, TILE_SIZE, MAP_W, MAP_H, MONSTERS, LOOT, MERCHANT_ITEMS, BOSS, CLASSES } from './data.js';
-import { render, renderInv, updateUI, resetScene } from './render.js';
+import { render, renderInv, updateUI, resetScene, randomizeWallTexture } from './render.js';
 
 // --- Game State and Logic ---
 export const G = {
@@ -146,6 +146,7 @@ function genMap() {
   }
 
   G.map = map; G.seen = seen; G.visible = visible; G.effects=[];
+  randomizeWallTexture();
   resetScene(); // force 3D scene rebuild
 
   // place monsters with scaling difficulty

--- a/rogue_lite_single_file_html_game.html
+++ b/rogue_lite_single_file_html_game.html
@@ -16,7 +16,7 @@
     html, body { height: 100%; margin: 0; background: var(--bg); color: #e6edf3; font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial; }
     .wrap { display: grid; grid-template-columns: 1fr 320px; gap: 12px; max-width: 1200px; margin: 10px auto; padding: 0 10px; }
     .gameview { position: relative; }
-    #view { background: #ffffff; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); width: 100%; aspect-ratio: 4/3; image-rendering: pixelated; }
+    #view { background: #dddddd; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); width: 100%; aspect-ratio: 4/3; image-rendering: pixelated; }
     #minimap { position: absolute; top: 10px; right: 10px; border: 2px solid #000; image-rendering: pixelated; }
     .side { background: var(--panel); border-radius: 12px; padding: 12px; display: grid; grid-template-rows: auto auto 1fr auto; gap: 10px; }
     h1 { font-size: 18px; margin: 0 0 4px; color: var(--accent); }


### PR DESCRIPTION
## Summary
- Replace black walls with light grey brick textures regenerated each floor
- Move camera closer and tint canvas background to reduce empty white space

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897cde556f0832e99e5a324f6329a3d