### PR TITLE
Use wait to open chests and descend

### DIFF
--- a/game.js
+++ b/game.js
@@ -267,11 +267,6 @@ function openShop(m){
   renderInv(); updateUI();
 }
 
-function pickup(){
-  if(G.map[G.player.y][G.player.x]===T.CHEST){ openChest(); return; }
-  log('Nothing to interact.');
-}
-
 function applyEquipStats(it, sign){
   if(it.hp){ G.player.hpMax += sign*it.hp; if(sign>0) G.player.hp += it.hp; }
   if(it.mp){ G.player.mpMax += sign*it.mp; if(sign>0) G.player.mp += it.mp; }
@@ -369,7 +364,18 @@ function move(dx,dy){
   tick();
 }
 
-function wait(){ log('You wait.'); tick(); }
+function wait(){
+  const tile = G.map[G.player.y][G.player.x];
+  if(tile===T.CHEST){
+    openChest();
+    tick();
+  } else if(tile===T.STAIRS){
+    descend();
+  } else {
+    log('You wait.');
+    tick();
+  }
+}
 
 function maybeDrop(mon){
   G.killCounts[mon.name] = (G.killCounts[mon.name] || 0) + 1;
@@ -585,4 +591,4 @@ function showWinScreen(){
   document.body.appendChild(modal);
 }
 
-export { log, move, entityAt, defeat, gainXP, tick, wait, ability, pickup, descend, discardItem, useItem, newPlayer, genMap };
+export { log, move, entityAt, defeat, gainXP, tick, wait, ability, descend, discardItem, useItem, newPlayer, genMap };

--- a/input.js
+++ b/input.js
@@ -1,5 +1,5 @@
 import { rngFromSeed } from './utils.js';
-import { G, move, entityAt, defeat, tick, wait, ability, pickup, descend, discardItem, useItem, newPlayer, genMap, log } from './game.js';
+import { G, move, entityAt, defeat, tick, wait, ability, discardItem, useItem, newPlayer, genMap, log } from './game.js';
 import { updateUI, render } from './render.js';
 
 // --- Input & Bootstrap ---
@@ -21,8 +21,6 @@ function onKey(e){
   }
   else if(k==='.' || k==='5') wait();
   else if(k===' '){ e.preventDefault(); ability(); }
-  else if(k==='g'){ pickup(); }
-  else if(k==='>'){ descend(); }
   else if(/^Digit[1-9]$/.test(e.code) || /^Numpad[1-9]$/.test(e.code)){
     const num = parseInt(e.code.slice(-1));
     if(e.shiftKey) discardItem(num-1);
@@ -48,7 +46,7 @@ document.getElementById('btnRestart').addEventListener('click', ()=>{
   window.removeEventListener('keydown', onKey);
 });
 document.getElementById('btnHelp').addEventListener('click', ()=>{
-  alert('Move: WASD/Arrows | Wait: . | Attack: F | Ability: Space | Open chest: G | Down stairs: >\nInventory: click item or press 1..9 to use, Shift+1..9 to drop');
+  alert('Move: WASD/Arrows | Wait: . | Attack: F | Ability: Space | Open chest/Descend: wait on chest/stairs\nInventory: click item or press 1..9 to use, Shift+1..9 to drop');
 });
 for(const b of document.querySelectorAll('.classbtn')){
   b.addEventListener('click', ()=> startRun(b.dataset.class));
@@ -64,7 +62,6 @@ for(const btn of document.querySelectorAll('#dpad button')){
     else { move(dx,dy); G.lastDir=[dx,dy]; }
   });
 }
-document.getElementById('btnMobilePickup')?.addEventListener('pointerdown', e=>{ e.preventDefault(); pickup(); });
 document.getElementById('btnMobileAbility')?.addEventListener('pointerdown', e=>{ e.preventDefault(); ability(); });
 
 // Start paused at class select

--- a/render.js
+++ b/render.js
@@ -292,7 +292,7 @@ function updateFigure(mesh, tx, ty){
 }
 
 function createPlayerMesh(cls){
-  const colors={warrior:0x880000,mage:0x000088,hunter:0x006600};
+  const colors={warrior:0xaa0000,mage:0x0000aa,hunter:0x008800};
   const group=createCharacterMesh(colors[cls]||0xffff00);
   if(cls==='warrior'){
     const sword=new THREE.Mesh(new THREE.BoxGeometry(0.05,0.05,0.8),new THREE.MeshLambertMaterial({color:0xcccccc}));

--- a/rogue_lite_single_file_html_game.html
+++ b/rogue_lite_single_file_html_game.html
@@ -101,7 +101,7 @@
       </div>
       <div class="controls">
         <b>Controls</b><br/>
-        Move: WASD / Arrow keys · Wait: . (period) · Attack: F (melee) · Ability: Space (class skill) · Open chest: G · Descend stairs: &gt; <br/>
+        Move: WASD / Arrow keys · Wait: . (period) · Attack: F (melee) · Ability: Space (class skill) · Open chest/Descend stairs: wait on chest/stairs <br/>
         Inventory: click item or press 1..9 to use, Shift+1..9 to drop<br/>
         Warrior ability: Whirlwind (hit all adjacent) · Mage: Fireball (AoE, 2x2) · Hunter: Shoot arrow (range 5)
       </div>
@@ -121,7 +121,6 @@
       <button class="dir" data-dx="1" data-dy="1">↘︎</button>
     </div>
     <div id="actions">
-      <button id="btnMobilePickup">Pickup</button>
       <button id="btnMobileAbility">Ability</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Remove dedicated pickup and descend keys; waiting on a chest opens it, waiting on stairs descends.
- Update help text, mobile layout, and controls to reflect the new interaction style.
- Lighten the base colors of warrior, mage, and hunter 3D models.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897e80890b4832ead0719d3e47044f6