### PR TITLE
Add victory fireworks and run stats

### DIFF
--- a/game.js
+++ b/game.js
@@ -551,41 +551,51 @@ function winGame(){
 }
 
 function launchFireworks(){
-  const spawn=()=>{
-    if(!G.win) return;
-    const x=(Math.random()*MAP_W)|0;
-    const y=(Math.random()*MAP_H)|0;
-    const color=`hsl(${(Math.random()*360)|0},100%,70%)`;
-    // celebratory firework removed
-    setTimeout(spawn,500+Math.random()*500);
+  const spawn = () => {
+    if (!G.win) return;
+    const x = (Math.random() * MAP_W) | 0;
+    const y = (Math.random() * MAP_H) | 0;
+    const color = `hsl(${(Math.random() * 360) | 0},100%,70%)`;
+    // trigger a simple expanding firework effect
+    playEffect({ type: 'firework', x, y, r: TILE_SIZE * 2, color }, 800);
+    setTimeout(spawn, 500 + Math.random() * 500);
   };
   spawn();
 }
 
-function showWinScreen(){
-  const modal=document.createElement('div');
-  modal.id='winModal';
-  modal.className='modal';
-  modal.style.background='rgba(0,0,0,0.5)';
-  const card=document.createElement('div');
-  card.className='card';
-  card.innerHTML='<h2>Victory!</h2><p>You recovered the crystal!</p>';
-  const stats=document.createElement('div');
-  stats.innerHTML='<h3>Monster Kills</h3>';
-  const list=document.createElement('div');
-  const entries=Object.entries(G.killCounts);
-  if(entries.length){
-    for(const [name,count] of entries){
-      const row=document.createElement('div');
-      row.textContent=`${name}: ${count}`;
+function showWinScreen() {
+  const modal = document.createElement('div');
+  modal.id = 'winModal';
+  modal.className = 'modal';
+  modal.style.background = 'rgba(0,0,0,0.5)';
+  const card = document.createElement('div');
+  card.className = 'card';
+  card.innerHTML = '<h2>Victory!</h2><p>You recovered the crystal!</p>';
+
+  const run = document.createElement('div');
+  run.innerHTML = `<h3>Run Stats</h3>
+    <div>Turns: ${G.turn}</div>
+    <div>Gold Collected: ${G.gold}</div>
+    <div>Floor Reached: ${G.floor}</div>`;
+
+  const stats = document.createElement('div');
+  stats.innerHTML = '<h3>Monster Kills</h3>';
+  const list = document.createElement('div');
+  const entries = Object.entries(G.killCounts);
+  if (entries.length) {
+    for (const [name, count] of entries) {
+      const row = document.createElement('div');
+      row.textContent = `${name}: ${count}`;
       list.appendChild(row);
     }
   } else {
-    const row=document.createElement('div');
-    row.textContent='None';
+    const row = document.createElement('div');
+    row.textContent = 'None';
     list.appendChild(row);
   }
   stats.appendChild(list);
+
+  card.appendChild(run);
   card.appendChild(stats);
   modal.appendChild(card);
   document.body.appendChild(modal);

--- a/render.js
+++ b/render.js
@@ -504,6 +504,18 @@ export function render() {
           ctx.fill();
         }
         ctx.globalAlpha = 1;
+      } else if (fx.type === 'firework') {
+        const cx = fx.x * TILE_SIZE + TILE_SIZE / 2, cy = fx.y * TILE_SIZE + TILE_SIZE / 2;
+        ctx.globalAlpha = 1 - p;
+        ctx.fillStyle = fx.color || 'rgba(255,200,0,0.8)';
+        for (let i = 0; i < 10; i++) {
+          const ang = (Math.PI * 2 / 10) * i;
+          const dist = fx.r * p;
+          ctx.beginPath();
+          ctx.arc(cx + Math.cos(ang) * dist, cy + Math.sin(ang) * dist, 3, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        ctx.globalAlpha = 1;
       } else if (fx.type === 'levelup') {
         const cx = fx.x * TILE_SIZE + TILE_SIZE / 2, cy = fx.y * TILE_SIZE + TILE_SIZE / 2;
         ctx.strokeStyle = fx.color || 'rgba(0,255,0,0.8)';
@@ -572,6 +584,14 @@ export function render() {
             const dist = (fx.r/TILE_SIZE)*p;
             const m = new THREE.Mesh(new THREE.SphereGeometry(0.1,6,6), new THREE.MeshBasicMaterial({color:0xcccccc, transparent:true, opacity:1-p}));
             m.position.set(fx.x+Math.cos(ang)*dist,0.25,fx.y+Math.sin(ang)*dist);
+            fxGroup.add(m);
+          }
+        } else if (fx.type === 'firework') {
+          for (let i = 0; i < 10; i++) {
+            const ang = (Math.PI * 2 / 10) * i;
+            const dist = (fx.r / TILE_SIZE) * p;
+            const m = new THREE.Mesh(new THREE.SphereGeometry(0.1, 8, 8), new THREE.MeshBasicMaterial({ color: new THREE.Color(fx.color || 0xffff00), transparent: true, opacity: 1 - p }));
+            m.position.set(fx.x + Math.cos(ang) * dist, 0.5, fx.y + Math.sin(ang) * dist);
             fxGroup.add(m);
           }
         } else if (fx.type === 'levelup') {


### PR DESCRIPTION
## Summary
- Trigger fireworks animation and display run stats when the Crystal Guardian falls
- Render colorful firework effects in both canvas and WebGL modes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68980b469894832eb53ed3dac747e5a3