### PR TITLE
Replace 3D models with pixel art sprites

### DIFF
--- a/data.js
+++ b/data.js
@@ -13,13 +13,13 @@ export const MAP_W = 40, MAP_H = 30; // 40x30 -> 960x720 canvas
 
 // Monsters (D&D-ish)
 export const MONSTERS = [
-  {name:'Goblin', icon:'👺', hp:6, atk:2, mp:0, speed:2, attack:'melee', xp:4},
-  {name:'Skeleton Archer', icon:'🏹', hp:8, atk:3, mp:0, speed:1, attack:'ranged', range:4, xp:6},
-  {name:'Orc', icon:'👹', hp:12, atk:4, mp:2, speed:1, attack:'melee', xp:10},
-  {name:'Zombie', icon:'🧟', hp:14, atk:3, mp:0, speed:0.5, attack:'melee', xp:10},
-  {name:'Mimic', icon:'📦', hp:10, atk:5, mp:0, speed:1, attack:'melee', xp:12},
-  {name:'Ogre', icon:'🧌', hp:18, atk:6, mp:0, speed:1, attack:'melee', xp:18},
-  {name:'Young Dragon', icon:'🐉', hp:28, atk:8, mp:10, speed:3, attack:'magic', range:5, cost:3, xp:30}
+  {name:'Goblin', icon:'👺', sprite:'goblin', hp:6, atk:2, mp:0, speed:2, attack:'melee', xp:4},
+  {name:'Skeleton Archer', icon:'🏹', sprite:'skeleton', hp:8, atk:3, mp:0, speed:1, attack:'ranged', range:4, xp:6},
+  {name:'Orc', icon:'👹', sprite:'orc', hp:12, atk:4, mp:2, speed:1, attack:'melee', xp:10},
+  {name:'Zombie', icon:'🧟', sprite:'zombie', hp:14, atk:3, mp:0, speed:0.5, attack:'melee', xp:10},
+  {name:'Mimic', icon:'📦', sprite:'mimic', hp:10, atk:5, mp:0, speed:1, attack:'melee', xp:12},
+  {name:'Ogre', icon:'🧌', sprite:'ogre', hp:18, atk:6, mp:0, speed:1, attack:'melee', xp:18},
+  {name:'Young Dragon', icon:'🐉', sprite:'dragon', hp:28, atk:8, mp:10, speed:3, attack:'magic', range:5, cost:3, xp:30}
 ];
 
 export const LOOT = {
@@ -47,10 +47,10 @@ export const MERCHANT_ITEMS = [
   {name:'Plate Armor +3', type:'equip', def:+3, hp:+10, cost:100}
 ];
 
-export const BOSS = {name:'Crystal Guardian', icon:'💠', hp:40, atk:9, mp:6, speed:0.5, attack:'magic', range:5, cost:3, xp:0};
+export const BOSS = {name:'Crystal Guardian', icon:'💠', sprite:'boss', hp:40, atk:9, mp:6, speed:0.5, attack:'magic', range:5, cost:3, xp:0};
 
 export const CLASSES = {
-  warrior: { hp: 30, mp: 0, atk: 5, def: 2, abilityCd: 5, icon:'⚔️' },
-  mage:    { hp: 18, mp: 20, atk: 2, def: 1, abilityCd: 0, icon:'🧙' },
-  hunter:  { hp: 24, mp: 8,  atk: 3, def: 1, abilityCd: 0, icon:'🏹', ammo: 40, ammoMax: 40 }
+  warrior: { hp: 30, mp: 0, atk: 5, def: 2, abilityCd: 5, icon:'⚔️', sprite:'warrior' },
+  mage:    { hp: 18, mp: 20, atk: 2, def: 1, abilityCd: 0, icon:'🧙', sprite:'mage' },
+  hunter:  { hp: 24, mp: 8,  atk: 3, def: 1, abilityCd: 0, icon:'🏹', ammo: 40, ammoMax: 40, sprite:'hunter' }
 };

--- a/game.js
+++ b/game.js
@@ -183,7 +183,7 @@ function placeMerchant(){
   let mx=0,my=0,tries=0;
   do{ mx=(rand()*w)|0; my=(rand()*h)|0; tries++; } while(G.map[my][mx]!==T.FLOOR && tries<1000);
   const stock = MERCHANT_ITEMS.map(it=>JSON.parse(JSON.stringify(it)));
-  G.entities.push({type:'merchant', name:'Merchant', icon:'💰', x:mx, y:my, stock});
+  G.entities.push({type:'merchant', name:'Merchant', icon:'💰', sprite:'merchant', x:mx, y:my, stock});
 }
 
 function placeBoss(){
@@ -207,7 +207,8 @@ function newPlayer(cls){
     inv: [],
     weapon: null, armor: null,
     ammo: base.ammo||0, ammoMax: base.ammoMax||0,
-    icon: base.icon || '@'
+    icon: base.icon || '@',
+    sprite: base.sprite || 'warrior'
   }
 }
 

--- a/render.js
+++ b/render.js
@@ -1,10 +1,11 @@
 import * as THREE from 'three';
 import { T, TILE_SIZE, MAP_W, MAP_H } from './data.js';
 import { G, useItem, discardItem } from './game.js';
+import { getSprite } from './sprites.js';
 
 // --- Rendering and UI ---
 // Toggle between classic 2D canvas rendering and experimental 3D using Three.js
-const USE_WEBGL = true;
+const USE_WEBGL = false;
 const canvas = document.getElementById('view');
 const minimap = document.getElementById('minimap');
 const mctx = minimap.getContext('2d');
@@ -94,6 +95,7 @@ if (USE_WEBGL) {
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.font = '20px sans-serif';
+  ctx.imageSmoothingEnabled = false;
 }
 
 resizeCanvas();
@@ -435,16 +437,16 @@ export function render() {
     // items
     for (const it of G.items) { if (!G.visible[it.y][it.x]) continue; ctx.fillStyle = '#ffd166'; ctx.fillRect(it.x * TILE_SIZE + 10, it.y * TILE_SIZE + 10, 4, 4); }
     // entities (monsters)
-    ctx.fillStyle = '#000';
     for (const e of G.entities) {
       if (!G.visible[e.y][e.x]) continue;
-      const px = e.x * TILE_SIZE + TILE_SIZE / 2, py = e.y * TILE_SIZE + TILE_SIZE / 2;
-      ctx.fillText(e.icon || e.ch || '?', px, py);
+      const px = e.x * TILE_SIZE;
+      const py = e.y * TILE_SIZE;
+      const spr = getSprite(e.sprite || e.type);
+      ctx.drawImage(spr, px, py, TILE_SIZE, TILE_SIZE);
     }
     // player
-    const px = G.player.x * TILE_SIZE + TILE_SIZE / 2, py = G.player.y * TILE_SIZE + TILE_SIZE / 2;
-    ctx.fillStyle = '#000';
-    ctx.fillText(G.player.icon || '@', px, py);
+    const pSpr = getSprite(G.player.sprite || 'warrior');
+    ctx.drawImage(pSpr, G.player.x * TILE_SIZE, G.player.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 
     // ability effects
     for (const fx of G.effects) {

--- a/sprites.js
+++ b/sprites.js
@@ -1,0 +1,34 @@
+export const ENTITY_COLORS = {
+  warrior: '#d4a373',
+  mage: '#6393ff',
+  hunter: '#8b4513',
+  goblin: '#00aa00',
+  skeleton: '#e0e0e0',
+  orc: '#225500',
+  zombie: '#88aa88',
+  mimic: '#8b5e34',
+  ogre: '#663300',
+  dragon: '#ff4444',
+  merchant: '#ffaa00',
+  boss: '#00ffff'
+};
+
+const cache = {};
+
+export function getSprite(name){
+  if(cache[name]) return cache[name];
+  const color = ENTITY_COLORS[name] || '#ff00ff';
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 16;
+  const ctx = canvas.getContext('2d');
+  ctx.imageSmoothingEnabled = false;
+  // body
+  ctx.fillStyle = color;
+  ctx.fillRect(0,0,16,16);
+  // simple eyes
+  ctx.fillStyle = '#000';
+  ctx.fillRect(4,4,2,2);
+  ctx.fillRect(10,4,2,2);
+  cache[name] = canvas;
+  return canvas;
+}


### PR DESCRIPTION
## Summary
- add centralized sprite resource with simple pixel-art generation
- tag classes, monsters, boss, and merchant with sprite identifiers
- switch renderer to 2D canvas and draw sprites instead of 3D models

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68980cbf3ea0832ea684620e3d422d38