### PR TITLE
Fix sprite depth testing and wait key

### DIFF
--- a/input.js
+++ b/input.js
@@ -19,7 +19,11 @@ function onKey(e){
       if(m.hp<=0){ defeat(m); } tick();
     } else log('No enemy to strike.');
   }
-  else if(k==='.' || k==='5') wait();
+  // Wait a turn: support period key across layouts and numpad center/decimal
+  else if(k==='.' || e.code==='Period' || e.code==='NumpadDecimal' || k==='5'){
+    e.preventDefault();
+    wait();
+  }
   else if(k===' '){ e.preventDefault(); ability(); }
   else if(/^Digit[1-9]$/.test(e.code) || /^Numpad[1-9]$/.test(e.code)){
     const num = parseInt(e.code.slice(-1));

--- a/render.js
+++ b/render.js
@@ -138,8 +138,10 @@ function createSpriteMesh(name){
   const mat = new THREE.SpriteMaterial({
     map: tex,
     transparent: true,
+    // Don't write to depth so walls behind can't clip the sprite, but
+    // still test against existing depth so walls in front occlude it.
     depthWrite: false,
-    depthTest: false
+    depthTest: true
   });
   const sprite = new THREE.Sprite(mat);
   sprite.scale.set(1,1,1);


### PR DESCRIPTION
## Summary
- Allow sprites to test against depth buffer so walls in front occlude them correctly
- Improve period key handling for wait action across keyboard layouts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689abb96694c832ebdeaa8abdebbf3f5