### PR TITLE
Fix missing sprite fallback to prevent disappearing sprites

### DIFF
--- a/sprites.js
+++ b/sprites.js
@@ -3,11 +3,15 @@ const cache = {};
 export function getSprite(name) {
   if (!cache[name]) {
     const img = new Image();
-    img.src = `resource/${encodeURIComponent(name)}.png`;
     img.onerror = () => {
+      // Fallback to default sprite if the requested image fails to load.
       img.onerror = null;
       img.src = 'resource/default.jpeg';
     };
+    // Set the source after assigning the error handler so that loading
+    // failures are always caught and a placeholder sprite is displayed
+    // instead of leaving the entity invisible.
+    img.src = `resource/${encodeURIComponent(name)}.png`;
     cache[name] = img;
   }
   return cache[name];


### PR DESCRIPTION
## Summary
- Ensure sprite loading assigns error handler before setting the source, so missing sprites use a default image instead of vanishing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b47eceea0832e9c3db750192224c9