### PR TITLE
Limit minimap vision and adjust class sight

### DIFF
--- a/data.js
+++ b/data.js
@@ -50,7 +50,7 @@ export const MERCHANT_ITEMS = [
 export const BOSS = {name:'Crystal Guardian', icon:'💠', hp:40, atk:9, mp:6, speed:0.5, attack:'magic', range:5, cost:3, xp:0};
 
 export const CLASSES = {
-  warrior: { hp: 30, mp: 0, atk: 5, def: 2, abilityCd: 5, icon:'⚔️' },
-  mage:    { hp: 18, mp: 20, atk: 2, def: 1, abilityCd: 0, icon:'🧙' },
-  hunter:  { hp: 24, mp: 8,  atk: 3, def: 1, abilityCd: 0, icon:'🏹', ammo: 40, ammoMax: 40 }
+  warrior: { hp: 30, mp: 0, atk: 5, def: 2, abilityCd: 5, icon:'⚔️', vision: 7 },
+  mage:    { hp: 18, mp: 20, atk: 2, def: 1, abilityCd: 0, icon:'🧙', vision: 7 },
+  hunter:  { hp: 24, mp: 8,  atk: 3, def: 1, abilityCd: 0, icon:'🏹', ammo: 40, ammoMax: 40, vision: 10 }
 };

--- a/game.js
+++ b/game.js
@@ -207,6 +207,7 @@ function newPlayer(cls){
     inv: [],
     weapon: null, armor: null,
     ammo: base.ammo||0, ammoMax: base.ammoMax||0,
+    vision: base.vision,
     icon: base.icon || '@'
   }
 }
@@ -301,7 +302,8 @@ function discardItem(i){
 
 // --- Field of View (simple LOS radius) ---
 function fov(){
-  const r=10; const {x:px,y:py}=G.player;
+  const r = G.player.vision;
+  const {x:px,y:py}=G.player;
   for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++) G.visible[y][x]=false;
   for(let y=py-r;y<=py+r;y++) for(let x=px-r;x<=px+r;x++){
     if(!between(x,0,MAP_W-1)||!between(y,0,MAP_H-1)) continue;

--- a/render.js
+++ b/render.js
@@ -299,7 +299,7 @@ function renderMinimap() {
   }
   mctx.fillStyle = 'red';
   for (const e of G.entities) {
-    if (!G.seen[e.y][e.x]) continue;
+    if (!G.visible[e.y][e.x]) continue;
     mctx.fillRect(e.x * sx, e.y * sy, sx, sy);
   }
   mctx.fillStyle = '#ffa500';


### PR DESCRIPTION
## Summary
- show only visible monsters on the minimap
- tune field of view per class (warrior/mage: 7, hunter: 10)

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b77b593fc832eaae5bc12c6278468