### PR TITLE
Remove trapdoor feature and reposition minimap

### DIFF
--- a/data.js
+++ b/data.js
@@ -5,8 +5,7 @@ export const T = {
   STAIRS: 2,
   CHEST: 3,
   WATER: 4,
-  FOUNTAIN: 5,
-  TRAP: 6
+  FOUNTAIN: 5
 };
 export const TILE_SIZE = 24; // pixels per tile
 export const MAP_W = 40, MAP_H = 30; // 40x30 -> 960x720 canvas

--- a/game.js
+++ b/game.js
@@ -140,10 +140,6 @@ function genMap() {
     const fx=(rand()*w)|0, fy=(rand()*h)|0;
     if(map[fy][fx]===T.FLOOR && !(fx===1&&fy===1)) map[fy][fx]=T.FOUNTAIN;
   }
-  for(let i=0;i<2;i++){ // trap doors
-    const tx=(rand()*w)|0, ty=(rand()*h)|0;
-    if(map[ty][tx]===T.FLOOR && !(tx===1&&ty===1)) map[ty][tx]=T.TRAP;
-  }
 
   G.map = map; G.seen = seen; G.visible = visible; G.effects=[];
   randomizeWallTexture();
@@ -355,10 +351,6 @@ function move(dx,dy){
     G.player.hp = Math.min(G.player.hpMax, G.player.hp+5);
     G.player.mp = Math.min(G.player.mpMax, G.player.mp+5);
     log('You feel refreshed by the fountain.');
-  } else if(tile===T.TRAP){
-    log('You fall through a trap door!');
-    descend();
-    return;
   }
   if(G.player.cls==='mage'){
     G.player.mp = Math.min(G.player.mpMax, G.player.mp + 1);

--- a/render.js
+++ b/render.js
@@ -51,37 +51,33 @@ function rect(x, y, w, h, col) {
   ctx.fillRect(x, y, w, h);
 }
 
-function drawTile(mx, my, t, startX, startY) {
-  const px = (mx - startX) * TILE_SIZE;
-  const py = (my - startY) * TILE_SIZE;
-  if (t === T.WALL) {
-    if (!wallPattern) wallPattern = ctx.createPattern(wallCanvas, 'repeat');
-    ctx.fillStyle = wallPattern;
-    ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
-  } else if (t === T.FLOOR) rect(px, py, TILE_SIZE, TILE_SIZE, '#dddddd');
-  else if (t === T.STAIRS) {
-    rect(px, py, TILE_SIZE, TILE_SIZE, '#654321');
-    ctx.fillStyle = '#333333';
-    ctx.fillRect(px + 4, py + 4, 16, 16);
-  } else if (t === T.CHEST) {
-    rect(px, py, TILE_SIZE, TILE_SIZE, '#dddddd');
-    ctx.fillStyle = '#8b5e34';
-    ctx.fillRect(px + 5, py + 6, 14, 12);
-    ctx.fillStyle = '#d4af37';
-    ctx.fillRect(px + 5, py + 12, 14, 2);
-  } else if (t === T.WATER) rect(px, py, TILE_SIZE, TILE_SIZE, '#cceeff');
-  else if (t === T.FOUNTAIN) {
-    rect(px, py, TILE_SIZE, TILE_SIZE, '#dddddd');
-    ctx.fillStyle = '#4fc3f7';
-    ctx.beginPath();
-    ctx.arc(px + TILE_SIZE / 2, py + TILE_SIZE / 2, 6, 0, Math.PI * 2);
-    ctx.fill();
-  } else if (t === T.TRAP) {
-    rect(px, py, TILE_SIZE, TILE_SIZE, '#dddddd');
-    ctx.fillStyle = '#000';
-    ctx.fillRect(px + 4, py + 4, 16, 16);
+  function drawTile(mx, my, t, startX, startY) {
+    const px = (mx - startX) * TILE_SIZE;
+    const py = (my - startY) * TILE_SIZE;
+    if (t === T.WALL) {
+      if (!wallPattern) wallPattern = ctx.createPattern(wallCanvas, 'repeat');
+      ctx.fillStyle = wallPattern;
+      ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
+    } else if (t === T.FLOOR) rect(px, py, TILE_SIZE, TILE_SIZE, '#dddddd');
+    else if (t === T.STAIRS) {
+      rect(px, py, TILE_SIZE, TILE_SIZE, '#654321');
+      ctx.fillStyle = '#333333';
+      ctx.fillRect(px + 4, py + 4, 16, 16);
+    } else if (t === T.CHEST) {
+      rect(px, py, TILE_SIZE, TILE_SIZE, '#dddddd');
+      ctx.fillStyle = '#8b5e34';
+      ctx.fillRect(px + 5, py + 6, 14, 12);
+      ctx.fillStyle = '#d4af37';
+      ctx.fillRect(px + 5, py + 12, 14, 2);
+    } else if (t === T.WATER) rect(px, py, TILE_SIZE, TILE_SIZE, '#cceeff');
+    else if (t === T.FOUNTAIN) {
+      rect(px, py, TILE_SIZE, TILE_SIZE, '#dddddd');
+      ctx.fillStyle = '#4fc3f7';
+      ctx.beginPath();
+      ctx.arc(px + TILE_SIZE / 2, py + TILE_SIZE / 2, 6, 0, Math.PI * 2);
+      ctx.fill();
+    }
   }
-}
 
 export function resetScene() {
   // no-op for 2D renderer

--- a/rogue_lite_single_file_html_game.html
+++ b/rogue_lite_single_file_html_game.html
@@ -17,7 +17,7 @@
     .wrap { display: grid; grid-template-columns: 1fr 320px; gap: 12px; max-width: 1200px; margin: 10px auto; padding: 0 10px; }
     .gameview { position: relative; }
     #view { background: #dddddd; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); width: 100%; aspect-ratio: 4/3; image-rendering: pixelated; }
-    #minimap { position: absolute; top: 10px; right: 10px; border: 2px solid #000; image-rendering: pixelated; }
+      #minimap { position: absolute; top: 10px; left: 10px; border: 2px solid #000; image-rendering: pixelated; }
     .side { background: var(--panel); border-radius: 12px; padding: 12px; display: grid; grid-template-rows: auto auto 1fr auto; gap: 10px; }
     h1 { font-size: 18px; margin: 0 0 4px; color: var(--accent); }
     .row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }


### PR DESCRIPTION
## Summary
- Remove trapdoor tiles from map generation, movement, and rendering logic.
- Adjust minimap positioning to avoid covering top-right of main view.

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_689b9cec495c832eae7c38f1240bfbee