### PR TITLE
Prevent merchant from obscuring player on floor 4

### DIFF
--- a/game.js
+++ b/game.js
@@ -177,9 +177,13 @@ function genMap() {
 function placeMerchant(){
   const {rand}=G.rng, w=MAP_W, h=MAP_H;
   let mx=0,my=0,tries=0;
-  do{ mx=(rand()*w)|0; my=(rand()*h)|0; tries++; } while(G.map[my][mx]!==T.FLOOR && tries<1000);
+  // ensure merchant doesn't spawn on player's starting tile
+  do{
+    mx=(rand()*w)|0; my=(rand()*h)|0; tries++;
+  } while((G.map[my][mx]!==T.FLOOR || (mx===1 && my===1)) && tries<1000);
   const stock = MERCHANT_ITEMS.map(it=>JSON.parse(JSON.stringify(it)));
-  G.entities.push({type:'merchant', name:'Merchant', icon:'💰', x:mx, y:my, stock});
+  // keep display name capitalized but specify sprite file explicitly
+  G.entities.push({type:'merchant', name:'Merchant', sprite:'merchant', icon:'💰', x:mx, y:my, stock});
 }
 
 function placeBoss(){

--- a/render.js
+++ b/render.js
@@ -150,7 +150,7 @@ export function render() {
   for (const e of G.entities) {
     if (!G.visible[e.y][e.x]) continue;
     if (e.x < startX || e.x >= startX + viewTilesX || e.y < startY || e.y >= startY + viewTilesY) continue;
-    const img = getSprite(e.name);
+    const img = getSprite(e.sprite || e.name);
     const sx = (e.x - startX) * TILE_SIZE;
     const sy = (e.y - startY) * TILE_SIZE;
     ctx.drawImage(img, sx, sy, TILE_SIZE, TILE_SIZE);


### PR DESCRIPTION
## Summary
- Ensure merchant never spawns on the player's starting tile
- Render entities using an explicit sprite name so merchant sprite loads correctly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f93873d20832e8c4d09ae5e827c82